### PR TITLE
backport fixes for some sanitizer errors

### DIFF
--- a/1.49.0/include/boost/algorithm/string/find_iterator.hpp
+++ b/1.49.0/include/boost/algorithm/string/find_iterator.hpp
@@ -230,7 +230,12 @@ namespace boost {
     
                 \post eof()==true
             */
-            split_iterator() {}
+            split_iterator() :
+                m_Next(),
+                m_End(),
+                m_bEof(true)
+            {}
+
             //! Copy constructor
             /*!
                 Construct a copy of the split_iterator

--- a/1.49.0/include/boost/any.hpp
+++ b/1.49.0/include/boost/any.hpp
@@ -15,6 +15,8 @@
 
 #include "boost/config.hpp"
 #include <boost/type_traits/remove_reference.hpp>
+#include <boost/type_traits/decay.hpp>
+#include <boost/type_traits/remove_cv.hpp>
 #include <boost/type_traits/is_reference.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/static_assert.hpp>
@@ -43,7 +45,9 @@ namespace boost
 
         template<typename ValueType>
         any(const ValueType & value)
-          : content(new holder<ValueType>(value))
+          : content(new holder<
+                BOOST_DEDUCED_TYPENAME remove_cv<BOOST_DEDUCED_TYPENAME decay<const ValueType>::type>::type
+            >(value))
         {
         }
 
@@ -181,7 +185,7 @@ namespace boost
 #else
             operand->type() == typeid(ValueType)
 #endif
-            ? &static_cast<any::holder<ValueType> *>(operand->content)->held
+            ? &static_cast<any::holder<BOOST_DEDUCED_TYPENAME remove_cv<ValueType>::type> *>(operand->content)->held
             : 0;
     }
 

--- a/1.49.0/include/boost/serialization/extended_type_info_typeid.hpp
+++ b/1.49.0/include/boost/serialization/extended_type_info_typeid.hpp
@@ -84,7 +84,9 @@ class extended_type_info_typeid :
 {
 public:
     extended_type_info_typeid() :
-        typeid_system::extended_type_info_typeid_0(get_key())
+        typeid_system::extended_type_info_typeid_0(
+            boost::serialization::guid< T >()
+        )
     {
         type_register(typeid(T));
         key_register();


### PR DESCRIPTION
Backported some fixes from 1.58.0
The most relevant is the `find_iterator.hpp` one, which left uninitialized the eof var.
The others are a constness mismatch (any.hpp)
And a "vptr not being of correct type", as the member function is being accessed prior to base-classes construction.